### PR TITLE
Add pin function

### DIFF
--- a/lib/gateways.js
+++ b/lib/gateways.js
@@ -8,6 +8,7 @@ var cm = require('sdk/context-menu');
 var prefs = require('sdk/simple-prefs').prefs;
 var ioservice = Cc['@mozilla.org/network/io-service;1'].getService(Ci.nsIIOService);
 var gui = require('./gui.js');
+var tabs = require("sdk/tabs");
 
 const IPFS_RESOURCE = /^https?:\/\/[^\/]+\/ip(f|n)s\//;
 var PUBLIC_GATEWAY_HOSTS; // getPublicGatewayHostsRegex()
@@ -95,6 +96,13 @@ function disableHttpGatewayRedirect(button) {
   if (button) button.state(button, gui.toggleStateDisabled);
 }
 
+function pin(address) {
+  let IPFS_API_URI = 'http://' + prefs.customGatewayHost + ':5001/api/v0';
+  let uri = ioservice.newURI(IPFS_API_URI+'/pin/add?arg='+address, null, null);
+  tabs.open(uri.spec);
+}
+
+exports.pin = pin;
 exports.ipfsRequestObserver = ipfsRequestObserver;
 exports.enableHttpGatewayRedirect = enableHttpGatewayRedirect;
 exports.disableHttpGatewayRedirect = disableHttpGatewayRedirect;

--- a/lib/gui.js
+++ b/lib/gui.js
@@ -85,11 +85,24 @@ const COPY_PUBLIC_HTTP_URL = cm.Item({
   }
 });
 
+const PIN_IPFS_ADDRESS = cm.Item({
+  label: 'Pin ipfs address',
+  contentScript: 'self.on("click", self.postMessage);',
+  onMessage: function() {
+    let ipfsURI = Cc['@mozilla.org/appshell/window-mediator;1']
+      .getService(Ci.nsIWindowMediator)
+      .getMostRecentWindow('navigator:browser')
+      .getBrowser().currentURI.spec;
+    gw.pin(ipfsURI.replace(gw.customUri().spec, '/'));
+  }
+});
+
+
 cm.Menu({
   label: 'IPFS',
-  items: [COPY_IPFS_ADDRESS, COPY_PUBLIC_HTTP_URL]
+  items: [PIN_IPFS_ADDRESS, COPY_IPFS_ADDRESS, COPY_PUBLIC_HTTP_URL]
 });
 
 exports.getMenuItemsContexts = function() {
-  return [COPY_PUBLIC_HTTP_URL.context, COPY_IPFS_ADDRESS.context];
+  return [PIN_IPFS_ADDRESS.context, COPY_PUBLIC_HTTP_URL.context, COPY_IPFS_ADDRESS.context];
 };


### PR DESCRIPTION
Please do not merge this, I just opened this to start a discussion. We could come up with a much better ux for pinning / unpinning I think:

1. make the current button act as pin/unpin, with ON/OFF being replaced with a pin icon. Right click the button to turn on and off the redirect, which would color/uncolor the logo.

2. create a second button just dedicated to pinning

3. make the button just pin/unpin, and ask people to enable/disable the addon like they do all other addons, in the addons preference pane.

All of these require better code:

1. Convert open new tab to ajax call that handles success/failure

2. Add unpin functionality

And probably want to not hard-code the :5001 port for the daemon (make it the default, allow for override like for the gateway)

Anyway, is this a feature people would like me to work on more?