### PR TITLE
Add custom api port

### DIFF
--- a/lib/pin.js
+++ b/lib/pin.js
@@ -10,19 +10,20 @@ var prefs = require('sdk/simple-prefs').prefs;
 const notifications = require('sdk/notifications');
 const Request = require('sdk/request').Request;
 
-function pin(address) {
+function pin (address) {
   address = address.split('#')[0]; // ignore URL hash
-  let IPFS_API_URI = 'http://' + prefs.customGatewayHost + ':5001/api/v0';
+  address = address.split('?')[0]; // ignore GET params
+  let IPFS_API_URI = 'http://' + prefs.customGatewayHost + ':' + prefs.customApiPort + '/api/v0';
   let uri = ioservice.newURI(IPFS_API_URI + '/pin/add?arg=' + address, null, null);
 
   new Request({
     url: uri.spec,
     onComplete: function (response) {
-      let pinned = response.json.Pinned;
+      let pinned = response.json.Pinned[0];
       notifications.notify({
-        title: pinned ? 'Pinned' : 'Failed to Pin',
-        text: address.slice(6) + ' (' + pinned + ')'
-      });
+        title: pinned ? 'Pinned' : 'Failed to pin',
+        text: pinned || address.slice(6)
+      })
     }
   }).get();
 }

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -4,4 +4,6 @@ customGatewayHost_title=Custom Gateway Host
 customGatewayHost_description=Most people want to use localhost (127.0.0.1)
 customGatewayPort_title=Custom Gateway Port
 customGatewayPort_description=HTTP2IPFS gateway service (eg. local instance of go-ipfs)
+customApiPort_title=Custom Api Port
+customApiPort_description=IPFS api service (uses same host as gateway)
 toggle_button_label=IPFS Gateway Redirect

--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
       "title": "Custom IPFS Gateway Port",
       "type": "integer",
       "value": 8080
+    },
+    {
+      "name": "customApiPort",
+      "title": "Custom IPFS API Port",
+      "type": "integer",
+      "value": 5001
     }
   ],
   "permissions": {


### PR DESCRIPTION
Also, filtered out any get query strings, which can be tested when you click Download on any ipfs.pics instance.